### PR TITLE
open doesn't work on some ubuntu, where xdg-open will

### DIFF
--- a/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
+++ b/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
@@ -81,7 +81,13 @@ trait WebPlot[T] extends Plottable[T] {
 
   def openWindow(link: String) = {
    import sys.process._
-    Try(s"open $link"!!).orElse(Try(s"xdg-open $link"!!)).recover{
+    Try{
+      java.awt.Desktop.getDesktop.browse(new java.net.URI(link))
+      link
+    }
+    .orElse(Try(s"open $link"!!))
+    .orElse(Try(s"xdg-open $link"!!))
+    .recover{
       case ex: Exception => s"Unable to open $link : in browser, ie trying to launch browser on a remote machine"
     }.get
   }

--- a/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
+++ b/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
@@ -1,7 +1,7 @@
 package com.quantifind.charts.repl
 
 import java.io.File
-import scala.util.Try
+import scala.util.{Failure, Try}
 import unfiltered.util.Port
 import unfiltered.jetty.Server
 
@@ -87,9 +87,6 @@ trait WebPlot[T] extends Plottable[T] {
     }
     .orElse(Try(s"open $link"!!))
     .orElse(Try(s"xdg-open $link"!!))
-    .recover{
-      case ex: Exception => s"Unable to open $link : in browser, ie trying to launch browser on a remote machine"
-    }.get
   }
 
   /**
@@ -98,8 +95,12 @@ trait WebPlot[T] extends Plottable[T] {
    */
   def openFirstWindow(link: String) = {
     if(!firstOpenWindow) {
-      val msg = openWindow(link)
-      if (msg.nonEmpty) println("Error on opening window: " + msg)
+      openWindow(link) match {
+        case Failure(msg) =>
+          println(s"Error while opening window (cause: $msg)")
+          println(s"You can browse the following URL: $link")
+        case _ =>
+      }
       firstOpenWindow = true
     }
   }

--- a/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
+++ b/core/src/main/scala/com/quantifind/charts/repl/PlotLike.scala
@@ -1,6 +1,7 @@
 package com.quantifind.charts.repl
 
 import java.io.File
+import scala.util.Try
 import unfiltered.util.Port
 import unfiltered.jetty.Server
 
@@ -79,12 +80,10 @@ trait WebPlot[T] extends Plottable[T] {
   startServer()
 
   def openWindow(link: String) = {
-    try {
-      import sys.process._
-      s"open $link".!!
-    } catch {
+   import sys.process._
+    Try(s"open $link"!!).orElse(Try(s"xdg-open $link"!!)).recover{
       case ex: Exception => s"Unable to open $link : in browser, ie trying to launch browser on a remote machine"
-    }
+    }.get
   }
 
   /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1"
+version in ThisBuild := "0.0.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
Just a small fix when trying to open an url on a (at least) ubuntu machine without "see".

Remark: I bumped the version for local test, but I can reset it and let you manage this of course (specially because I didn't use SNAPSHOT).

Oh, thanks for this cool project!!! 
Would love to see:
* vega (for commercial usage)
* integrated in the [SparkNotebook](https://github.com/andypetrella/spark-notebook/) I'm creating