### PR TITLE
Create unstack, which returns the stack type to None

### DIFF
--- a/core/src/main/scala/com/quantifind/charts/Highcharts.scala
+++ b/core/src/main/scala/com/quantifind/charts/Highcharts.scala
@@ -107,7 +107,8 @@ object Highcharts extends IterablePairLowerPriorityImplicits with BinnedDataLowe
       "xAxis(String)" -> "adds a label to the x-axis",
       "yAxis(String)" -> "adds a label to y-axis",
       "legend(Iterable[String])" -> "adds a legend to the most recent plot",
-      """stack(["normal", "percent"])""" -> "stacks bars, columns, and lines relative to each other"
+      """stack(["normal", "percent"])""" -> "stacks bars, columns, and lines relative to each other",
+      """unstack""" -> "remove stacking"
     ).foreach{case(method, description) => println("\t%-35s%s".format(method, description))}
 
     println("\nServer Controls:\n")

--- a/core/src/main/scala/com/quantifind/charts/repl/HighchartsImpl.scala
+++ b/core/src/main/scala/com/quantifind/charts/repl/HighchartsImpl.scala
@@ -169,4 +169,11 @@ trait HighchartsStyles extends Hold[Highchart] with Labels[Highchart] with WebPl
     val newPlot = plot.copy(plotOptions = Some(PlotOptions(series = PlotOptionKey(stacking = stackType))))
     super.plot(newPlot)
   }
+
+  def unstack(): Highchart = {
+    val plot = plots.head
+    plots = plots.tail
+    val newPlot = plot.copy(plotOptions = Some(PlotOptions(series = PlotOptionKey(stacking = None))))
+    super.plot(newPlot)
+  }
 }


### PR DESCRIPTION
Creates unstack, which undoes a call to stack by making the type of the most recent plot None. #18 