### PR TITLE
austin: support axis min max

### DIFF
--- a/core/src/main/scala/com/quantifind/charts/highcharts/Highchart.scala
+++ b/core/src/main/scala/com/quantifind/charts/highcharts/Highchart.scala
@@ -644,6 +644,8 @@ case class Axis(
       "lineWidth" -> lineWidth,
       //    "maxPadding" -> maxPadding,
       //    "minPadding" -> minPadding,
+      "max" -> max,
+      "min" -> min,
       "offset" -> offset,
       "opposite" -> opposite,
       "reversed" -> reversed,


### PR DESCRIPTION
Fixes #34 , min and max were erroneously left out of the axis fields lists

@vineetgoel1992 can you confirm this and cut a 0.0.5 branch for this and category axis names? :-)

I left heatmaps 85% finished but haven't had the time to revisit :(